### PR TITLE
Update findingaid.xsl

### DIFF
--- a/finding-aid-files/findingaid.xsl
+++ b/finding-aid-files/findingaid.xsl
@@ -143,7 +143,7 @@
       </div>
       <div class="panel-body">
         <ul>
-          <xsl:for-each select="ead:controlaccess/*[@source='lcsh']">
+          <xsl:for-each select="ead:controlaccess/*">
             <li><xsl:value-of select="." /></li>
           </xsl:for-each>
         </ul>


### PR DESCRIPTION
updated controlled access headings to display *all* access headings, not just LCSH

Ref #19 